### PR TITLE
Remove custom script to install bundler < 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: ruby
 sudo: false
 cache: bundler
 
-before_install:
-  - type bundle >/dev/null 2>&1 || gem install bundler -v '< 2'
-
 rvm:
   - 2.2.10
   - 2.3.8


### PR DESCRIPTION
Travis fixed installing the correct bundler version depending on the ruby version used by the build